### PR TITLE
Fix projector receive focus when unminimizing

### DIFF
--- a/src/main/java/xyz/duncanruns/jingle/obs/OBSProjector.java
+++ b/src/main/java/xyz/duncanruns/jingle/obs/OBSProjector.java
@@ -2,6 +2,7 @@ package xyz.duncanruns.jingle.obs;
 
 import com.sun.jna.Pointer;
 import com.sun.jna.platform.win32.WinDef;
+import com.sun.jna.platform.win32.WinUser;
 import xyz.duncanruns.jingle.Jingle;
 import xyz.duncanruns.jingle.util.MonitorUtil;
 import xyz.duncanruns.jingle.util.PidUtil;
@@ -128,7 +129,17 @@ public final class OBSProjector {
     }
 
     public static void unminimizeProjector() {
-        WindowStateUtil.ensureNotMinimized(projectorHwnd);
+        if (projectorHwnd == null) return;
+
+        WinUser.WINDOWPLACEMENT windowplacement = new WinUser.WINDOWPLACEMENT();
+        windowplacement.length = windowplacement.size();
+
+        if (User32.INSTANCE.GetWindowPlacement(projectorHwnd, windowplacement).booleanValue()) {
+            if (windowplacement.showCmd == WinUser.SW_SHOWMINIMIZED) {
+                windowplacement.showCmd = WinUser.SW_SHOWNOACTIVATE;
+                User32.INSTANCE.SetWindowPlacement(projectorHwnd, windowplacement);
+            }
+        }
     }
 
     private static void setProjectorZOrder(int hwndInsertAfter) {


### PR DESCRIPTION
OBS projector will be minimized when minimize option is checked, and `unminimizeProjector` unminimizes the projector by calling `ensureNotMinimized`. This works well under normal circumstances , but when the OBS is minimized, `ensureNotMinimized` causes focus to be taken away from the game instance.

Using `SetWindowPlacement` to set `showCmd` to `SW_SHOWNOACTIVATE` might be a solution.