### PR TITLE
Fix Jingle crash

### DIFF
--- a/src/main/java/xyz/duncanruns/jingle/instance/InstanceInfo.java
+++ b/src/main/java/xyz/duncanruns/jingle/instance/InstanceInfo.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 public class InstanceInfo {
     // Version Patterns
     private static final Pattern VANILLA_VERSION_PATTERN = Pattern.compile(" --version (fabric-loader-\\d\\.\\d+(\\.\\d+)?-)?(.+?) ");
-    private static final Pattern MULTIMC_VERSION_PATTERN = Pattern.compile("minecraft-(.+)-client.jar");
+    private static final Pattern MULTIMC_VERSION_PATTERN = Pattern.compile("com/mojang/minecraft/[^/\\\\]+/minecraft-([^;]+)-client.jar");
     private static final Pattern MULTIMC_VERSION_PATTERN_2 = Pattern.compile("intermediary/(.+)/intermediary");
     // Vanilla Path Patterns
     private static final Pattern VANILLA_PATH_PATTERN = Pattern.compile("--gameDir (.+?) ");


### PR DESCRIPTION
happens if you have `minecraft-` in either java path or multimc path
<img width="1303" height="738" alt="image" src="https://github.com/user-attachments/assets/2b8714aa-bb44-4591-8f0f-3fd9fe51b7a5" />
